### PR TITLE
Implement Send+Sync for TxBlocking

### DIFF
--- a/src/mpmc/tx.rs
+++ b/src/mpmc/tx.rs
@@ -76,6 +76,9 @@ impl<T, S: MPMCShared> TxBlocking<T, S> {
 
 }
 
+unsafe impl<T: Send, S: MPMCShared> Send for TxBlocking<T, S> {}
+unsafe impl<T: Send, S: MPMCShared> Sync for TxBlocking<T, S> {}
+
 pub struct TxFuture<T, S: MPMCShared> {
     sender: Sender<T>,
     shared: Arc<S>,

--- a/src/mpsc/tx.rs
+++ b/src/mpsc/tx.rs
@@ -73,6 +73,9 @@ impl<T, S: MPSCShared> TxBlocking<T, S> {
 
 }
 
+unsafe impl<T: Send, S: MPSCShared> Send for TxBlocking<T, S> {}
+unsafe impl<T: Send, S: MPSCShared> Sync for TxBlocking<T, S> {}
+
 pub struct TxFuture<T, S: MPSCShared> {
     sender: Sender<T>,
     shared: Arc<S>,


### PR DESCRIPTION
Should be safe to implement `Send` and `Sync` for `TxBlocking` if the type sent is also `Send`.